### PR TITLE
AutoValue 1.3

### DIFF
--- a/auto-value-with/src/main/java/com/gabrielittner/auto/value/with/AutoValueWithExtension.java
+++ b/auto-value-with/src/main/java/com/gabrielittner/auto/value/with/AutoValueWithExtension.java
@@ -4,13 +4,11 @@ import com.gabrielittner.auto.value.util.Property;
 import com.google.auto.service.AutoService;
 import com.google.auto.value.extension.AutoValueExtension;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.TypeSpec;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
@@ -31,14 +29,8 @@ public class AutoValueWithExtension extends AutoValueExtension {
     }
 
     @Override
-    public Set<String> consumeProperties(Context context) {
-        //TODO AutoValue 1.3: use consumeMethods(Context) instead
-        ImmutableSet<ExecutableElement> methods = WithMethod.filterMethods(context);
-        Set<String> consumedProperties = new HashSet<>(methods.size());
-        for (ExecutableElement method : methods) {
-            consumedProperties.add(method.getSimpleName().toString());
-        }
-        return consumedProperties;
+    public Set<ExecutableElement> consumeMethods(Context context) {
+        return WithMethod.filterMethods(context);
     }
 
     @Override

--- a/auto-value-with/src/main/java/com/gabrielittner/auto/value/with/WithMethod.java
+++ b/auto-value-with/src/main/java/com/gabrielittner/auto/value/with/WithMethod.java
@@ -24,8 +24,6 @@ import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Types;
 import javax.tools.Diagnostic.Kind;
 
-import static com.google.auto.common.MoreElements.getLocalAndInheritedMethods;
-
 class WithMethod {
 
     private static final String PREFIX = "with";
@@ -87,30 +85,15 @@ class WithMethod {
     }
 
     static ImmutableSet<ExecutableElement> filterMethods(Context context) {
-        ImmutableSet<ExecutableElement> methods = getAbstractMethods(context);
-        List<ExecutableElement> withMethods = new ArrayList<>(methods.size());
-        for (ExecutableElement method : methods) {
+        Set<ExecutableElement> abstractMethods = context.abstractMethods();
+        List<ExecutableElement> withMethods = new ArrayList<>(abstractMethods.size());
+        for (ExecutableElement method : abstractMethods) {
             if (method.getSimpleName().toString().startsWith(PREFIX)
                     && method.getParameters().size() > 0) {
                 withMethods.add(method);
             }
         }
         return ImmutableSet.copyOf(withMethods);
-    }
-
-    private static ImmutableSet<ExecutableElement> getAbstractMethods(Context context) {
-        //TODO AutoValue 1.3: replace with context.getAbstractMethods()
-        ProcessingEnvironment environment = context.processingEnvironment();
-        TypeElement autoValueClass = context.autoValueClass();
-        ImmutableSet<ExecutableElement> methods =
-                getLocalAndInheritedMethods(autoValueClass, environment.getElementUtils());
-        List<ExecutableElement> abstractMethods = new ArrayList<>(methods.size());
-        for (ExecutableElement method : methods) {
-            if (method.getModifiers().contains(Modifier.ABSTRACT)) {
-                abstractMethods.add(method);
-            }
-        }
-        return ImmutableSet.copyOf(abstractMethods);
     }
 
     private static String removePrefix(String name) {

--- a/auto-value-with/src/test/java/com/gabrielittner/auto/value/with/AutoValueWithExtensionTest.java
+++ b/auto-value-with/src/test/java/com/gabrielittner/auto/value/with/AutoValueWithExtensionTest.java
@@ -231,42 +231,6 @@ public final class AutoValueWithExtensionTest {
     }
 
     @Test
-    public void dontImplementNonAbstractWithMethod() {
-        //TODO AutoValue 1.3: we're getting only abstract methods from AV
-        JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
-                + "package test;\n"
-                + "import com.google.auto.value.AutoValue;\n"
-                + "@AutoValue public abstract class Test {\n"
-                + "  public abstract String a();\n"
-                + "  public abstract String b();\n"
-                + "  abstract Test withA(String a);\n"
-                + "  Test withB(String b) {\n"
-                + "    return null;\n"
-                + "  }\n"
-                + "}\n");
-
-        JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/AutoValue_Test", ""
-                + "package test;\n"
-                + "import java.lang.Override;\n"
-                + "import java.lang.String;\n"
-                + "final class AutoValue_Test extends $AutoValue_Test {\n"
-                + "  AutoValue_Test(String a, String b) {\n"
-                + "    super(a, b);\n"
-                + "  }\n"
-                + "  @Override final Test withA(String a) {\n"
-                + "    return new AutoValue_Test(a, b());\n"
-                + "  }\n"
-                + "}\n");
-
-        assertAbout(javaSources())
-                .that(Collections.singletonList(source))
-                .processedWith(new AutoValueProcessor())
-                .compilesWithoutError()
-                .and()
-                .generatesSources(expectedSource);
-    }
-
-    @Test
     public void prefixedMethods() {
         JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
                 + "package test;\n"

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ ext {
 
 ext.deps = [
         javapoet: 'com.squareup:javapoet:1.7.0',
-        auto_value: 'com.google.auto.value:auto-value:1.2',
+        auto_value: 'com.google.auto.value:auto-value:1.3-rc1',
         auto_common: 'com.google.auto:auto-common:0.6',
         auto_ext_util: 'com.gabrielittner.auto.value:auto-value-extension-util:0.2.1',
 


### PR DESCRIPTION
- use `consumeMethods(Context)` instead of  `consumeProperties(Context)` (**was breaking 1.3**)
- use new `Context.abstractMethods()` instead of searching them manually